### PR TITLE
Match Firaxis' ActionGroup and Criteria naming

### DIFF
--- a/example-generated-mod/mod-test.modinfo
+++ b/example-generated-mod/mod-test.modinfo
@@ -11,7 +11,7 @@
         <Mod id="base-standard" title="LOC_MODULE_BASE_STANDARD_NAME"/>
     </Dependencies>
     <ActionCriteria>
-        <Criteria id="age-antiquity-current">
+        <Criteria id="antiquity-age-current">
             <AgeInUse>AGE_ANTIQUITY</AgeInUse>
         </Criteria>
         <Criteria id="always">
@@ -19,7 +19,7 @@
         </Criteria>
     </ActionCriteria>
     <ActionGroups>
-        <ActionGroup id="65ff3d65-ab5b-48cd-a138-cd82c4ef82ca" scope="game" criteria="age-antiquity-current">
+        <ActionGroup id="age-antiquity-current" scope="game" criteria="antiquity-age-current">
             <Actions>
                 <UpdateDatabase>
                     <Item>civilizations/gondor/current.xml</Item>

--- a/examples/civilization.ts
+++ b/examples/civilization.ts
@@ -1,16 +1,22 @@
 import {
     ACTION_GROUP_BUNDLE,
+    AGE,
     CivilizationBuilder,
+    CivilizationUnlockBuilder,
+    COLLECTION,
     CONSTRUCTIBLE_TYPE_TAG,
-    ConstructibleBuilder, ConstructibleLocalization,
+    ConstructibleBuilder,
     DISTRICT,
+    EFFECT,
     ImportFileBuilder,
+    LeaderUnlockBuilder,
     Mod,
-    TAG_TRAIT, TRAIT,
-    UNIT,
+    REQUIREMENT,
+    TAG_TRAIT,
+    TRAIT,
     UNIT_CLASS,
+    UNIT,
     UnitBuilder, YIELD,
-    AGE, CivilizationUnlockBuilder, COLLECTION, EFFECT, LeaderUnlockBuilder, REQUIREMENT
 } from "./src";
 
 let mod = new Mod({

--- a/examples/import-custom-icon.ts
+++ b/examples/import-custom-icon.ts
@@ -1,4 +1,10 @@
-import { ACTION_GROUP_BUNDLE, CivilizationBuilder, ImportFileBuilder, Mod, TAG_TRAIT } from "./src";
+import {
+    ACTION_GROUP_BUNDLE,
+    CivilizationBuilder,
+    ImportFileBuilder,
+    Mod,
+    TAG_TRAIT
+} from "./src";
 
 let mod = new Mod({
     id: 'mod-test',

--- a/examples/import-sql-file.ts
+++ b/examples/import-sql-file.ts
@@ -1,4 +1,9 @@
-import { ACTION_GROUP_BUNDLE, CivilizationBuilder, ImportFileBuilder, Mod, TAG_TRAIT } from "./src";
+import {
+    ACTION_GROUP,
+    ACTION_GROUP_ACTION,
+    ImportFileBuilder,
+    Mod
+} from "./src";
 
 let mod = new Mod({
     id: 'mod-test',

--- a/examples/progression-tree.ts
+++ b/examples/progression-tree.ts
@@ -12,10 +12,10 @@ import {
     ProgressionTreeNodeBuilder,
     REQUIREMENT,
     TAG_TRAIT,
+    TraditionBuilder,
     TRAIT,
     UNIT_CLASS
 } from "./src";
-import { TraditionBuilder } from "../src";
 
 let mod = new Mod({
     id: 'mod-test',

--- a/examples/unique-quarter.ts
+++ b/examples/unique-quarter.ts
@@ -1,17 +1,20 @@
 import {
     ACTION_GROUP_BUNDLE,
     CivilizationBuilder,
+    COLLECTION,
     CONSTRUCTIBLE_TYPE_TAG,
-    ConstructibleBuilder, ConstructibleLocalization,
+    ConstructibleBuilder,
     DISTRICT,
+    EFFECT,
     ImportFileBuilder,
     Mod,
+    ModifierBuilder,
+    REQUIREMENT,
     TAG_TRAIT, TRAIT,
-    UNIT,
+    UniqueQuarterBuilder,
     UNIT_CLASS,
-    UnitBuilder, YIELD
+    YIELD,
 } from "./src";
-import { COLLECTION, EFFECT, ModifierBuilder, REQUIREMENT, UniqueQuarterBuilder } from "../src";
 
 let mod = new Mod({
     id: 'mod-test',

--- a/examples/unit.ts
+++ b/examples/unit.ts
@@ -1,4 +1,10 @@
-import { ACTION_GROUP_BUNDLE, Mod, UNIT, UNIT_CLASS, UnitBuilder } from "./src";
+import {
+    ACTION_GROUP_BUNDLE,
+    Mod,
+    UNIT_CLASS,
+    UNIT,
+    UnitBuilder
+} from "./src";
 
 let mod = new Mod({
     id: 'mod-test',

--- a/examples/unlock-builder.ts
+++ b/examples/unlock-builder.ts
@@ -1,4 +1,9 @@
-import { REQUIREMENT, REQUIREMENT_SET, RESOURCE, UnlockBuilder } from "./src";
+import {
+    REQUIREMENT_SET,
+    REQUIREMENT,
+    RESOURCE,
+    UnlockBuilder
+} from "./src";
 
 const civilizationUnlock = new UnlockBuilder({
     unlockConfigurationValue: {

--- a/src/constants/ACTION_GROUP.ts
+++ b/src/constants/ACTION_GROUP.ts
@@ -4,9 +4,9 @@ import { CriteriaNode } from "../nodes/CriteriaNode";
 
 import { AGE } from "./AGE";
 
-// NB: IDs on ActionGroups and CriteriaNodes on these consts are set to follow  Firaxis'
+// NB: IDs on ActionGroups and CriteriaNodes for the ages are set to follow  Firaxis'
 // conventions present the main game files in e.g. Base\modules\age-antiquity\age-antiquity.modinfo.
-export const ACTION_GROUP = {
+const actionGroupInternal = {
     SHELL: new ActionGroupNode({
         scope: 'shell',
         criteria: new CriteriaNode({ id: 'always' })
@@ -63,4 +63,25 @@ export const ACTION_GROUP = {
             ages: [AGE.MODERN]
         })
     }),
+};
+
+const actionGroupDeprecatedProps = {
+    /**
+     * @deprecated Use AGE_ANTIQUITY_PERSIST directly instead. This may be removed in a future release
+     */
+    AGE_ANTIQUITY_EXIST: actionGroupInternal.AGE_ANTIQUITY_PERSIST,
+    /**
+     * @deprecated Use AGE_EXPLORATION_PERSIST directly instead. This may be removed in a future release
+     */
+    AGE_EXPLORATION_EXIST: actionGroupInternal.AGE_EXPLORATION_PERSIST,
+    /**
+     * @deprecated Use AGE_MODERN_PERSIST directly instead. This may be removed in a future release
+     */
+    AGE_MODERN_EXIST: actionGroupInternal.AGE_MODERN_PERSIST,
+};
+
+export const ACTION_GROUP = {
+    ...actionGroupInternal,
+    ...actionGroupDeprecatedProps
 } as const;
+

--- a/src/constants/ACTION_GROUP.ts
+++ b/src/constants/ACTION_GROUP.ts
@@ -4,6 +4,8 @@ import { CriteriaNode } from "../nodes/CriteriaNode";
 
 import { AGE } from "./AGE";
 
+// NB: IDs on ActionGroups and CriteriaNodes on these consts are set to follow  Firaxis'
+// conventions present the main game files in e.g. Base\modules\age-antiquity\age-antiquity.modinfo.
 export const ACTION_GROUP = {
     SHELL: new ActionGroupNode({
         scope: 'shell',
@@ -14,44 +16,50 @@ export const ACTION_GROUP = {
         criteria: new CriteriaNode({ id: 'always' })
     }),
     AGE_ANTIQUITY_CURRENT: new ActionGroupNode({
+        id: `age-antiquity-current`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-antiquity-current`,
+            id: `antiquity-age-current`,
             ages: [AGE.ANTIQUITY]
         })
     }),
-    AGE_ANTIQUITY_EXIST: new ActionGroupNode({
+    AGE_ANTIQUITY_PERSIST: new ActionGroupNode({
+        id: `age-antiquity-persist`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-antiquity-exist`,
+            id: `antiquity-age-persist`,
             ages: [AGE.ANTIQUITY, AGE.EXPLORATION, AGE.MODERN]
         })
     }),
     AGE_EXPLORATION_CURRENT: new ActionGroupNode({
+        id: `age-exploration-current`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-exploration-current`,
+            id: `exploration-age-current`,
             ages: [AGE.EXPLORATION]
         })
     }),
-    AGE_EXPLORATION_EXIST: new ActionGroupNode({
+    AGE_EXPLORATION_PERSIST: new ActionGroupNode({
+        id: `age-exploration-persist`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-exploration-exist`,
+            id: `exploration-age-persist`,
             ages: [AGE.EXPLORATION, AGE.MODERN]
         })
     }),
     AGE_MODERN_CURRENT: new ActionGroupNode({
+        id: `age-modern-current`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-modern-current`,
+            id: `modern-age-current`,
             ages: [AGE.MODERN]
         })
     }),
-    AGE_MODERN_EXIST: new ActionGroupNode({
+    AGE_MODERN_PERSIST: new ActionGroupNode({
+        id: `age-modern-persist`,
         scope: 'game',
         criteria: new CriteriaNode({
-            id: `age-modern-exist`,
+            id: `modern-age-persist`,
             ages: [AGE.MODERN]
         })
     }),

--- a/src/constants/ACTION_GROUP.ts
+++ b/src/constants/ACTION_GROUP.ts
@@ -6,7 +6,34 @@ import { AGE } from "./AGE";
 
 // NB: IDs on ActionGroups and CriteriaNodes for the ages are set to follow  Firaxis'
 // conventions present the main game files in e.g. Base\modules\age-antiquity\age-antiquity.modinfo.
-const actionGroupInternal = {
+
+
+const ageAntiquityPersist = new ActionGroupNode({
+    id: `age-antiquity-persist`,
+    scope: 'game',
+    criteria: new CriteriaNode({
+        id: `antiquity-age-persist`,
+        ages: [AGE.ANTIQUITY, AGE.EXPLORATION, AGE.MODERN]
+    })
+})
+const ageExplorationPersist = new ActionGroupNode({
+    id: `age-exploration-persist`,
+    scope: 'game',
+    criteria: new CriteriaNode({
+        id: `exploration-age-persist`,
+        ages: [AGE.EXPLORATION, AGE.MODERN]
+    })
+})
+const ageModernPersist = new ActionGroupNode({
+    id: `age-modern-persist`,
+    scope: 'game',
+    criteria: new CriteriaNode({
+        id: `modern-age-persist`,
+        ages: [AGE.MODERN]
+    })
+})
+
+export const ACTION_GROUP = {
     SHELL: new ActionGroupNode({
         scope: 'shell',
         criteria: new CriteriaNode({ id: 'always' })
@@ -23,14 +50,7 @@ const actionGroupInternal = {
             ages: [AGE.ANTIQUITY]
         })
     }),
-    AGE_ANTIQUITY_PERSIST: new ActionGroupNode({
-        id: `age-antiquity-persist`,
-        scope: 'game',
-        criteria: new CriteriaNode({
-            id: `antiquity-age-persist`,
-            ages: [AGE.ANTIQUITY, AGE.EXPLORATION, AGE.MODERN]
-        })
-    }),
+    AGE_ANTIQUITY_PERSIST: ageAntiquityPersist,
     AGE_EXPLORATION_CURRENT: new ActionGroupNode({
         id: `age-exploration-current`,
         scope: 'game',
@@ -39,14 +59,7 @@ const actionGroupInternal = {
             ages: [AGE.EXPLORATION]
         })
     }),
-    AGE_EXPLORATION_PERSIST: new ActionGroupNode({
-        id: `age-exploration-persist`,
-        scope: 'game',
-        criteria: new CriteriaNode({
-            id: `exploration-age-persist`,
-            ages: [AGE.EXPLORATION, AGE.MODERN]
-        })
-    }),
+    AGE_EXPLORATION_PERSIST: ageExplorationPersist,
     AGE_MODERN_CURRENT: new ActionGroupNode({
         id: `age-modern-current`,
         scope: 'game',
@@ -55,33 +68,21 @@ const actionGroupInternal = {
             ages: [AGE.MODERN]
         })
     }),
-    AGE_MODERN_PERSIST: new ActionGroupNode({
-        id: `age-modern-persist`,
-        scope: 'game',
-        criteria: new CriteriaNode({
-            id: `modern-age-persist`,
-            ages: [AGE.MODERN]
-        })
-    }),
-};
+    AGE_MODERN_PERSIST: ageModernPersist,
 
-const actionGroupDeprecatedProps = {
     /**
-     * @deprecated Use AGE_ANTIQUITY_PERSIST directly instead. This may be removed in a future release
+     * @deprecated Use AGE_ANTIQUITY_PERSIST directly instead. Preserved for backwards
+     * compatibility and may be removed in a future release
      */
-    AGE_ANTIQUITY_EXIST: actionGroupInternal.AGE_ANTIQUITY_PERSIST,
+    AGE_ANTIQUITY_EXIST: ageAntiquityPersist,
     /**
-     * @deprecated Use AGE_EXPLORATION_PERSIST directly instead. This may be removed in a future release
+     * @deprecated Use AGE_EXPLORATION_PERSIST directly instead. Preserved for backwards
+     * compatibility and may be removed in a future release
      */
-    AGE_EXPLORATION_EXIST: actionGroupInternal.AGE_EXPLORATION_PERSIST,
+    AGE_EXPLORATION_EXIST: ageExplorationPersist,
     /**
-     * @deprecated Use AGE_MODERN_PERSIST directly instead. This may be removed in a future release
+     * @deprecated Use AGE_MODERN_PERSIST directly instead. Preserved for backwards
+     * compatibility and may be removed in a future release
      */
-    AGE_MODERN_EXIST: actionGroupInternal.AGE_MODERN_PERSIST,
-};
-
-export const ACTION_GROUP = {
-    ...actionGroupInternal,
-    ...actionGroupDeprecatedProps
+    AGE_MODERN_EXIST: ageModernPersist,
 } as const;
-

--- a/src/constants/ACTION_GROUP_BUNDLE.ts
+++ b/src/constants/ACTION_GROUP_BUNDLE.ts
@@ -8,18 +8,18 @@ export const ACTION_GROUP_BUNDLE = {
         shell: ACTION_GROUP.SHELL,
         always: ACTION_GROUP.GAME,
         current: ACTION_GROUP.AGE_ANTIQUITY_CURRENT,
-        exist: ACTION_GROUP.AGE_ANTIQUITY_EXIST
+        persist: ACTION_GROUP.AGE_ANTIQUITY_PERSIST
     }),
     [AGE.EXPLORATION]: new ActionGroupBundle({
         shell: ACTION_GROUP.SHELL,
         always: ACTION_GROUP.GAME,
         current: ACTION_GROUP.AGE_EXPLORATION_CURRENT,
-        exist: ACTION_GROUP.AGE_EXPLORATION_EXIST
+        persist: ACTION_GROUP.AGE_EXPLORATION_PERSIST
     }),
     [AGE.MODERN]: new ActionGroupBundle({
         shell: ACTION_GROUP.SHELL,
         always: ACTION_GROUP.GAME,
         current: ACTION_GROUP.AGE_MODERN_CURRENT,
-        exist: ACTION_GROUP.AGE_MODERN_EXIST
+        persist: ACTION_GROUP.AGE_MODERN_PERSIST
     }),
 } as const;

--- a/src/core/ActionGroupBundle.ts
+++ b/src/core/ActionGroupBundle.ts
@@ -8,7 +8,7 @@ export class ActionGroupBundle {
     shell: ActionGroupNode = new ActionGroupNode();
     always: ActionGroupNode = new ActionGroupNode();
     current: ActionGroupNode = new ActionGroupNode();
-    exist: ActionGroupNode = new ActionGroupNode();
+    persist: ActionGroupNode = new ActionGroupNode();
 
     constructor(payload: Partial<TActionGroupBundleActionGroupBundle> = {}) {
         this.fill(payload);


### PR DESCRIPTION
Heya, this is a PR relating to https://forums.civfanatics.com/threads/modding-tools-framework-written-on-typescript.696255/#post-16806672 - making the `ACTION_GROUP.ts` consts align with Firaxis' naming for ActionGroup and Criteria for the current and persistent age unlocks.

- The ID naming is a fairly inconsequential change, just nice to align with the Firaxis approach for people like me poking round in the files and trying to work out how they work, and follow common practice! 
- The change from `exist` > `persist` should make the purpose of that a bit more clear - to ensure that unlocks **persist** through the following ages.

To minimise the chance of this being a breaking change, I left the old `ACTION_GROUP.AGE_[AGE_NAME]_EXIST` props in, but these point to the new `ACTION_GROUP.AGE_[AGE_NAME]_PERSIST` values, and are marked as deprecated so tooling should tell you not to use them. Then if you do a semver major bump later, you could delete the deprecated props?
![image](https://github.com/user-attachments/assets/aa309de2-58d8-4a9e-ba62-5576950bc789)

Update: I haven't included the compiled files in this PR - did test compile and make some amendments just to make sure the deprecated jsdoc is included though. There's a separate branch that I'm importing into my project atm at https://github.com/Oblongmana/civ7-modding-tools/tree/feature/match-firaxis-action-group-and-criteria-naming-plus-recompile - no version bump on it though.

Detailed notes from the commit:
```
Firaxis' core files (e.g.
Base/modules/age-antiquity/age-antiquity.modinfo) use age-[age_name] in
ActionGroup IDs, and [age_name]-age in Criteria IDs - this commit aligns
the consts in ACTION_GROUP.ts with those.

"exist" references have been changed to "persist" - this is the Firaxis
convention, and better reflects their purpose (to make something
"persist" through subsequent ages)
```